### PR TITLE
docs: fix malformed url in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ end)
 
 After that, restart Neovim, and you're ready to go!
 
-For a real-world example, check out [Meowim](https://github.com/loicyan/Meowim).
+For a real-world example, check out [Meowim](https://github.com/loichyan/Meowim).
 
 ## ⚙️ Configuration
 


### PR DESCRIPTION
As per title, PR fixes a minor typo in the README when referencing Meowim. :)